### PR TITLE
Fix Geant4 library installation

### DIFF
--- a/cmake/Modules/TOPAS_InstallExternalLibs.cmake
+++ b/cmake/Modules/TOPAS_InstallExternalLibs.cmake
@@ -6,9 +6,9 @@ if (TOPAS_WITH_STATIC_GEANT4)
 		"${Geant4_DIR}/../*.a")
 else ()
 	file (GLOB geant4libs 
-		"${Geant4_DIR}/../*.so*" 
-		"${Geant4_DIR}/../*.dylib"
-		"${Geant4_DIR}/../*.lib")
+		"${Geant4_DIR}/../../*.so*"
+		"${Geant4_DIR}/../../*.dylib"
+		"${Geant4_DIR}/../../*.lib")
 endif ()
 
 file (GLOB gdcmlibs 


### PR DESCRIPTION
While the current installation include wrapping TOPAS in a shell script to set up the environment, it is a common practice to configure the environment using environment configuration files like `.bashrc`. In this vein, I think there are some current linking/installation issues which are currently smoothed over with the shell script configuration (setting of `LD_LIBRARY_PATH`) and manual copying of files: https://github.com/OpenTOPAS/OpenTOPAS/blob/85b9e951bc53ca06a120dd22d9cfeb4915bb7660/OpenTOPAS_quickStart_WSL.md?plain=1#L197 

This PR fixes the geant4 library linking, possibly arising from a change in geant4 installation structure. Using the following command in the cmake to show the difference
```
message(STATUS "Geant4_DIR: ${Geant4_DIR}")
message(STATUS "Geant4 libraries: ${geant4libs}")
```

Before the change:
```
-- Geant4_DIR: /Applications/geant4-v11.1.3-install/lib/cmake/Geant4
-- Geant4 libraries:
```

After the change:
```
-- Geant4_DIR: /Applications/geant4-v11.1.3-install/lib/cmake/Geant4
-- Geant4 libraries: /Applications/geant4-v11.1.3-install/lib/cmake/Geant4/../../libG4FR.dylib;/Applications/geant4-v11.1.3-install/lib/cmake/Geant4/../../libG4GMocren.dylib;/Applications/geant4-v11.1.3-install/lib/cmake/Geant4/../../libG4OpenGL.dylib;/Applications/geant4-v11.1.3-install/lib/cmake/Geant4/../../libG4RayTracer.dylib;/Applications/geant4-v11.1.3-install/lib/cmake/Geant4/../../libG4ToolsSG.dylib;/Applications/geant4-v11.1.3-install/lib/cmake/Geant4/../../libG4Tree.dylib;/Applications/geant4-v11.1.3-install/lib/cmake/Geant4/../../libG4VRML.dylib;/Applications/geant4-v11.1.3-install/lib/cmake/Geant4/../../libG4analysis.dylib;/Applications/geant4-v11.1.3-install/lib/cmake/Geant4/../../libG4clhep.dylib;/Applications/geant4-v11.1.3-install/lib/cmake/Geant4/../../libG4digits_hits.dylib;/Applications/geant4-v11.1.3-install/lib/cmake/Geant4/../../libG4error_propagation.dylib;/Applications/geant4-v11.1.3-install/lib/cmake/Geant4/../../libG4event.dylib;/Applications/geant4-v11.1.3-install/lib/cmake/Geant4/../../libG4geometry.dylib;/Applications/geant4-v11.1.3-install/lib/cmake/Geant4/../../libG4global.dylib;/Applications/geant4-v11.1.3-install/lib/cmake/Geant4/../../libG4graphics_reps.dylib;/Applications/geant4-v11.1.3-install/lib/cmake/Geant4/../../libG4intercoms.dylib;/Applications/geant4-v11.1.3-install/lib/cmake/Geant4/../../libG4interfaces.dylib;/Applications/geant4-v11.1.3-install/lib/cmake/Geant4/../../libG4materials.dylib;/Applications/geant4-v11.1.3-install/lib/cmake/Geant4/../../libG4modeling.dylib;/Applications/geant4-v11.1.3-install/lib/cmake/Geant4/../../libG4parmodels.dylib;/Applications/geant4-v11.1.3-install/lib/cmake/Geant4/../../libG4particles.dylib;/Applications/geant4-v11.1.3-install/lib/cmake/Geant4/../../libG4persistency.dylib;/Applications/geant4-v11.1.3-install/lib/cmake/Geant4/../../libG4physicslists.dylib;/Applications/geant4-v11.1.3-install/lib/cmake/Geant4/../../libG4processes.dylib;/Applications/geant4-v11.1.3-install/lib/cmake/Geant4/../../libG4ptl.2.3.3.dylib;/Applications/geant4-v11.1.3-install/lib/cmake/Geant4/../../libG4ptl.2.dylib;/Applications/geant4-v11.1.3-install/lib/cmake/Geant4/../../libG4ptl.dylib;/Applications/geant4-v11.1.3-install/lib/cmake/Geant4/../../libG4readout.dylib;/Applications/geant4-v11.1.3-install/lib/cmake/Geant4/../../libG4run.dylib;/Applications/geant4-v11.1.3-install/lib/cmake/Geant4/../../libG4track.dylib;/Applications/geant4-v11.1.3-install/lib/cmake/Geant4/../../libG4tracking.dylib;/Applications/geant4-v11.1.3-install/lib/cmake/Geant4/../../libG4visHepRep.dylib;/Applications/geant4-v11.1.3-install/lib/cmake/Geant4/../../libG4visQt3D.dylib;/Applications/geant4-v11.1.3-install/lib/cmake/Geant4/../../libG4vis_management.dylib;/Applications/geant4-v11.1.3-install/lib/cmake/Geant4/../../libG4zlib.dylib
```

This allowed for the exclusion of the `LD_LIBRARY_PATH` appending of geant4 libraries in my configuration.

