### PR TITLE
Add parameter to visualize electric fields

### DIFF
--- a/graphics/TsGraphicsView.cc
+++ b/graphics/TsGraphicsView.cc
@@ -46,7 +46,7 @@
 TsGraphicsView::TsGraphicsView(TsParameterManager* pM, TsGraphicsManager* grM, TsGeometryManager* gM, G4String viewerName)
 :fPm(pM), fGrm(grM), fGm(gM), fViewerName(viewerName), fRefreshEvery("run"), fColorModel("charge"),
 fIncludeGeometry(true), fIncludeTrajectories(true), fUseSmoothTrajectories(true), fIncludeStepPoints(false), fIncludeAxes(false),
-fIsActive(true), fAlreadyCreated(false), fMagneticFieldArrowDensity(0), fHadParameterChangeSinceLastRun(false)
+fIsActive(true), fAlreadyCreated(false), fElectricFieldArrowDensity(0), fMagneticFieldArrowDensity(0), fHadParameterChangeSinceLastRun(false)
 {
 	fVerbosity = fPm->GetIntegerParameter("Ts/SequenceVerbosity");
 
@@ -88,6 +88,9 @@ void TsGraphicsView::CreateView() {
 	if (fPm->ParameterExists(GetFullParmName("IncludeAxes")) &&
 		fPm->GetBooleanParameter(GetFullParmName("IncludeAxes")))
 		fIncludeAxes = true;
+
+	if (fPm->ParameterExists(GetFullParmName("ElectricFieldArrowDensity")))
+		fElectricFieldArrowDensity = fPm->GetIntegerParameter(GetFullParmName("ElectricFieldArrowDensity"));
 
 	if (fPm->ParameterExists(GetFullParmName("MagneticFieldArrowDensity")))
 		fMagneticFieldArrowDensity = fPm->GetIntegerParameter(GetFullParmName("MagneticFieldArrowDensity"));
@@ -173,6 +176,12 @@ void TsGraphicsView::CreateView() {
 			G4cerr << "Gr/" << fViewerName << "/AxesComponent is set to unknown component: " << axesComponentName << G4endl;
 			fPm->AbortSession(1);
 		}
+	}
+
+	// Control electric field visualization
+	if (fElectricFieldArrowDensity > 0) {
+		G4String electricFieldCommand = "/vis/scene/add/electricField " + G4UIcommand::ConvertToString(fElectricFieldArrowDensity);
+		G4UImanager::GetUIpointer()->ApplyCommand(electricFieldCommand);
 	}
 
 	// Control magnetic field visualization

--- a/graphics/TsGraphicsView.hh
+++ b/graphics/TsGraphicsView.hh
@@ -80,6 +80,7 @@ private:
 	G4bool fIsActive;
 	G4bool fAlreadyCreated;
 	G4int fMagneticFieldArrowDensity;
+	G4int fElectricFieldArrowDensity;
 	G4bool fHadParameterChangeSinceLastRun;
 };
 


### PR DESCRIPTION
Introduce a new parameter for electric field visualization, allowing users to control the density of electric field arrows in the graphics view.

Usage:

"i:Gr/[view]/ElectricFieldArrowDensity = [nDataPointsPerHalfExtent]"

It is just a proxy of the Geant4 command "/vis/scene/add/electricField [nDataPointsPerHalfExtent]"