### PR TITLE
Register TsDicomActivityMap and fix modality tag buffer overflow

### DIFF
--- a/geometry/TsDicomActivityMap.cc
+++ b/geometry/TsDicomActivityMap.cc
@@ -134,7 +134,7 @@ void TsDicomActivityMap::ReadImage()
 		modalityTags = fPm->GetStringVector(GetFullParmName("DicomModalityTags"));
 		nModalityTags = fPm->GetVectorLength(GetFullParmName("DicomModalityTags"));
 	} else {
-		modalityTags = new G4String[1];
+		modalityTags = new G4String[2];
 		modalityTags[0] = "NM";
 		modalityTags[1] = "PT";
 		nModalityTags = 2;

--- a/geometry/TsGeometryHub.cc
+++ b/geometry/TsGeometryHub.cc
@@ -323,7 +323,15 @@ void TsGeometryHub::RegisterBuiltInTypes(GeometryRegistry& registry) {
         {{"s:Ge/{child}/DicomDirectory", ""},
             {"s:Ge/{child}/ImagingToMaterialConverter", ""},
             {"s:Ge/{child}/DicomRTStructFile", ""}}});
-    
+
+    AddType(registry, {"TsDicomActivityMap",
+        [](TsParameterManager* pM, TsExtensionManager* eM, TsMaterialManager* mM, TsGeometryManager*$
+            return new TsDicomActivityMap(pM, eM, mM, gM, pgc, pv, childName);
+        },
+        nullptr,
+        {{"s:Ge/{child}/DicomDirectory", ""},
+            {"i:Ge/{child}/LowerCountThreshold", "0"}}});
+
     AddType(registry, {"TsBox",
         [](TsParameterManager* pM, TsExtensionManager* eM, TsMaterialManager* mM, TsGeometryManager* gM, TsVGeometryComponent* pgc, G4VPhysicalVolume* pv, G4String& childName) {
             return new TsBox(pM, eM, mM, gM, pgc, pv, childName);

--- a/geometry/TsGeometryHub.cc
+++ b/geometry/TsGeometryHub.cc
@@ -325,7 +325,7 @@ void TsGeometryHub::RegisterBuiltInTypes(GeometryRegistry& registry) {
             {"s:Ge/{child}/DicomRTStructFile", ""}}});
 
     AddType(registry, {"TsDicomActivityMap",
-        [](TsParameterManager* pM, TsExtensionManager* eM, TsMaterialManager* mM, TsGeometryManager*, TsVGeometryComponent* pgc, G4VPhysicalVolume* pv, G4String& childName) {
+        [](TsParameterManager* pM, TsExtensionManager* eM, TsMaterialManager* mM, TsGeometryManager* gM, TsVGeometryComponent* pgc, G4VPhysicalVolume* pv, G4String& childName) {
             return new TsDicomActivityMap(pM, eM, mM, gM, pgc, pv, childName);
         },
         nullptr,

--- a/geometry/TsGeometryHub.cc
+++ b/geometry/TsGeometryHub.cc
@@ -325,7 +325,7 @@ void TsGeometryHub::RegisterBuiltInTypes(GeometryRegistry& registry) {
             {"s:Ge/{child}/DicomRTStructFile", ""}}});
 
     AddType(registry, {"TsDicomActivityMap",
-        [](TsParameterManager* pM, TsExtensionManager* eM, TsMaterialManager* mM, TsGeometryManager*$
+        [](TsParameterManager* pM, TsExtensionManager* eM, TsMaterialManager* mM, TsGeometryManager*, TsVGeometryComponent* pgc, G4VPhysicalVolume* pv, G4String& childName) {
             return new TsDicomActivityMap(pM, eM, mM, gM, pgc, pv, childName);
         },
         nullptr,


### PR DESCRIPTION
  ## Problem
  TsDicomActivityMap was compiled in but not registered in `TsGeometryHub`, so
  this component type could not be constructed at runtime.
