### PR TITLE
Minor fixes so that quickStart guides are consistent with RTD

### DIFF
--- a/OpenTOPAS_quickStart_Debian.md
+++ b/OpenTOPAS_quickStart_Debian.md
@@ -13,7 +13,7 @@ These instructions target **v4.2.2** built against Geant4 **v11.3.2**.
 > **Steps 1-4 are used to prepare your system for installation of OpenTOPAS**. Run these steps from a "terminal" window when logged in as a user with administrative privileges (a so-called super user or su). 
 
 > [!TIP]
-> Steps 1 to 4 are only needed if you have never installed the necessary libraries, `Cmake`, `git` or `qt5`. Otherwise you can skip these steps.
+> Steps 1 to 4 are only needed if you have never installed the necessary libraries, `Cmake`, `git` or `qt6`. Otherwise you can skip these steps.
 
 ## Step 1
 Install the following libraries (you can copy commands from here and paste them to your terminal):
@@ -45,12 +45,12 @@ Install `git`:
 > This step is only necessary if you want to clone OpenTOPAS source code from the GitHub repository (recommended). See Step 8.1 for more details.
 
 ## Step 4
-Install `qt5`:
+Install `qt6`:
 
         sudo apt install qt6-base-dev qt6-base-dev-tools qt6-tools-dev qt6-tools-dev-tools libqt6opengl6-dev 
 
 > [!WARNING]
-> The visualization of the current version of OpenTOPAS is only compatible with `qt`, not `qt` versions. 
+> The visualization of the current version of OpenTOPAS is only compatible with `qt6`, not `qt5` versions. 
 
 > [!NOTE]
 > Steps 5-7 are used to install Geant4, the Monte Carlo toolkit that provides the radiation transport.
@@ -116,7 +116,7 @@ and decompress them using `tar -zxf`.
 ## Step 7
 Build Geant4.
 
-7.1. Check where qt5 is stored in your system. The commands below assume it is at `/usr/lib/qt5`. In case qt5 is not stored in that directory in your system, replace the directory path after the command `-DCMAKE_PREFIX_PATH=` by the appropriate directory. 
+7.1. Check where qt6 is stored in your system. The commands below assume it is at `/usr/lib/qt6`. In case qt6 is not stored in that directory in your system, replace the directory path after the command `-DCMAKE_PREFIX_PATH=` by the appropriate directory. 
 
 7.2. Run the following commands: 
 
@@ -138,8 +138,6 @@ Downloading and installing OpenTOPAS and GDCM.
         mkdir $HOME/Applications/TOPAS
         cd $HOME/Applications/TOPAS
         git clone https://github.com/OpenTOPAS/OpenTOPAS.git
-        cd OpenTOPAS
-        git checkout v4.2.2
 
 8.1.b Alternatively, you can download OpenTOPAS manually. For a manual download, go to the OpenTOPAS GitHub [website](https://github.com/OpenTOPAS/OpenTOPAS/tree/master), click on the green tab named `<> Code` and `Download ZIP`. Create a directory called `TOPAS` in your `$HOME/Applications` directory, move the compressed folder into this directory, and decompress the file. To follow the following commands, rename the decompressed folder `OpenTOPAS-main` as `OpenTOPAS`. You should have the directory `$HOME/Applications/TOPAS/Open-TOPAS` 
 

--- a/OpenTOPAS_quickStart_MacOS.md
+++ b/OpenTOPAS_quickStart_MacOS.md
@@ -24,8 +24,9 @@ Install [Homebrew](https://brew.sh/). Access the Homebrew website given in Step 
 
 Follow the instructions posted to your terminal at the end of the Homebrew installation; e.g., enter the following commands:
 
-        (echo; echo 'eval "$(/opt/homebrew/bin/brew shellenv)"') >> $HOME/.zprofile
-        eval "$(/opt/homebrew/bin/brew shellenv)"
+        echo >> $HOME/.zprofile
+        echo 'eval "$(/opt/homebrew/bin/brew shellenv zsh)"' >> $HOME/.zprofile
+        eval "$(/opt/homebrew/bin/brew shellenv zsh)"
 
 ## Step 3
 Once Homebrew is installed, you will have access to the command `brew install`. Use this command to install `qt`, `git`, `wget`, and `cmake` by entering the following commands into your terminal:
@@ -108,11 +109,6 @@ Build Geant4. Take note of the following warnings before running the commands sh
 > Using the most recent versions of CMake might trigger undesireable warnings or errors. If this occurs we **recommend downgrading to 3.24.3 or 3.28.1**, which have been confirmed to work.
 
 > [!WARNING]
-> Verify that `qt@5` is not linked or installed in your system. The following command should yield no output if `qt@5` is indeed **NOT** installed on your system. See the warning at the top of the document about `qt@5` compatibility.
-
-        brew list --versions qt@5
-
-> [!WARNING]
 > Depending on your MacOS version you may or may not have XQuartz installed on your system. This can be tested with the following command which should yield no output if it is **NOT** installed. If this is the case please head to the official [Xquartz](https://www.xquartz.org) website to download the application.
 
         which xquartz
@@ -136,7 +132,8 @@ Replace the path supplied to `DCMAKE_PREFIX_PATH` in step 6.2 with the output of
                                 -DGEANT4_BUILD_VERBOSE_CODE=OFF \
                                 -DCMAKE_INSTALL_PREFIX=../geant4-install \
                                 -DCMAKE_PREFIX_PATH=/opt/homebrew/Cellar/qt/6.9.3 \
-                                -DGEANT4_USE_QT=ON -DGEANT4_USE_OPENGL=ON \
+                                -DGEANT4_USE_QT=ON -DGEANT4_USE_QT_QT6=ON -DGEANT4_USE_OPENGL=ON \
+                                -DGEANT4_USE_SYSTEM_ZLIB=ON
                                 -DCMAKE_OSX_ARCHITECTURES=arm64
         make -j20 install
 
@@ -154,8 +151,6 @@ Downloading and installing OpenTOPAS and GDCM.
         mkdir -p /Applications/TOPAS
         cd /Applications/TOPAS
         git clone https://github.com/OpenTOPAS/OpenTOPAS.git
-        cd OpenTOPAS
-        git checkout v4.2.2
 
 7.2. Next, check if the /Applications/GDCM already exists (GDCM is already installed). If so, rename the directory to GDCM-OLD (or another name) using the following command. 
 
@@ -185,9 +180,11 @@ Then use the following commands to move GDCM(<em>gdcm-2.6.8.tar.gz</em>) from th
         cd /Applications/TOPAS
         mkdir OpenTOPAS-{build,install}
         cd OpenTOPAS-build
+        QT_PREFIX=$(brew --prefix qt)
+        export CMAKE_PREFIX_PATH="$QT_PREFIX:$CMAKE_PREFIX_PATH"
         export Geant4_DIR=/Applications/GEANT4/geant4-install \
                GDCM_DIR=/Applications/GDCM/gdcm-install/
-        cmake ../OpenTOPAS -DCMAKE_INSTALL_PREFIX=../OpenTOPAS-install
+        cmake ../OpenTOPAS -DCMAKE_INSTALL_PREFIX=../OpenTOPAS-install -DTOPAS_USE_QT=ON -DTOPAS_USE_QT6=ON -DCMAKE_PREFIX_PATH=$"QT_PREFIX"
         make -j20 install
 
 ## Step 8

--- a/OpenTOPAS_quickStart_MacOS.md
+++ b/OpenTOPAS_quickStart_MacOS.md
@@ -184,7 +184,7 @@ Then use the following commands to move GDCM(<em>gdcm-2.6.8.tar.gz</em>) from th
         export CMAKE_PREFIX_PATH="$QT_PREFIX:$CMAKE_PREFIX_PATH"
         export Geant4_DIR=/Applications/GEANT4/geant4-install \
                GDCM_DIR=/Applications/GDCM/gdcm-install/
-        cmake ../OpenTOPAS -DCMAKE_INSTALL_PREFIX=../OpenTOPAS-install -DTOPAS_USE_QT=ON -DTOPAS_USE_QT6=ON -DCMAKE_PREFIX_PATH=$"QT_PREFIX"
+        cmake ../OpenTOPAS -DCMAKE_INSTALL_PREFIX=../OpenTOPAS-install -DTOPAS_USE_QT=ON -DTOPAS_USE_QT6=ON -DCMAKE_PREFIX_PATH="$QT_PREFIX"
         make -j20 install
 
 ## Step 8

--- a/OpenTOPAS_quickStart_WSL.md
+++ b/OpenTOPAS_quickStart_WSL.md
@@ -183,7 +183,7 @@ Compile GDCM as follows:
         cd OpenTOPAS
         mkdir gdcm-install
         mkdir gdcm-build
-        tar -zxf gdcm-2.6.8.tar,gz
+        tar -zxf gdcm-2.6.8.tar.gz
         cd gdcm-build
         cmake ../gdcm-2.6.8 -DGDCM_BUILD_SHARED_LIBS=ON -DGCM_BUILD_DOCBOOK_MANPAGES:BOOL=OFF -DCMAKE_INSTALL_PREFIX=../gdcm-install
         sudo make -j10 install


### PR DESCRIPTION
Just some minor fixes.

In the future I would like to modify the documentation repo such that it pulls from these files so edits only need to be made in a single place.