### PR TITLE
Fix 32-bit file-size overflow in PhaseSpace source for large IAEA files

### DIFF
--- a/primary/TsSourcePhaseSpace.cc
+++ b/primary/TsSourcePhaseSpace.cc
@@ -40,6 +40,7 @@
 #include <fstream>
 #include <sys/stat.h>
 #include <cmath>
+#include <filesystem>
 
 #ifdef TOPAS_MT
 #include "G4MTRunManager.hh"
@@ -396,7 +397,10 @@ void TsSourcePhaseSpace::ReadSomeDataFromFileToBuffer(std::queue<TsPrimaryPartic
 #endif
 
     G4String dataFileSpec = fFileName+".phsp";
-    fDataFile.open(dataFileSpec);
+    if (fIsBinary || fIsLimited)
+        fDataFile.open(dataFileSpec, std::ios::binary);
+    else
+        fDataFile.open(dataFileSpec);
     if (!fDataFile) {
         G4cerr << "Error opening phase space data file:" << dataFileSpec << G4endl;
         fPm->AbortSession(1);
@@ -692,9 +696,12 @@ G4bool TsSourcePhaseSpace::ReadOneParticle(std::queue<TsPrimaryParticle>* partic
 }
 
 
-G4long TsSourcePhaseSpace::GetFileSize(std::string filename)
+int64_t TsSourcePhaseSpace::GetFileSize(std::string filename)
 {
-    struct stat stat_buf;
-    int rc = stat(filename.c_str(), &stat_buf);
-    return rc == 0 ? stat_buf.st_size : -1;
+    // Plain stat() uses a 32-bit off_t on some platforms (notably Windows/MinGW),
+    // which overflows/fails for files larger than ~2 GB (common for IAEA phase
+    // space files). std::filesystem::file_size is 64-bit safe everywhere.
+    std::error_code ec;
+    std::uintmax_t size = std::filesystem::file_size(filename, ec);
+    return ec ? -1 : static_cast<int64_t>(size);
 }

--- a/primary/TsSourcePhaseSpace.hh
+++ b/primary/TsSourcePhaseSpace.hh
@@ -37,6 +37,7 @@
 
 #include <queue>
 #include <fstream>
+#include <cstdint>
 
 class TsSourcePhaseSpace : public TsSource
 {
@@ -50,12 +51,12 @@ public:
 
     G4bool ReadOneParticle(std::queue<TsPrimaryParticle>* particleBuffer);
 
-    G4long GetFileSize(std::string filename);
+    int64_t GetFileSize(std::string filename);
 
 private:
 	G4String fFileName;
     G4int fRecordLength;
-    G4long fFileSize;
+    int64_t fFileSize;
     std::ifstream fDataFile;
     std::streampos fFilePosition;
     G4String fAsciiLine;


### PR DESCRIPTION
Fixes #278

## Problem
`TsSourcePhaseSpace::GetFileSize()` uses the 32-bit POSIX `stat()`/`struct stat` to get the `.phsp` file size. On Windows/MinGW, `off_t` is 32-bit, so `stat()` fails outright for files larger than ~2 GB - a very common size for real linac-head IAEA phase space files (the one that triggered this was 4.17 GB). The `fFileSize` member is also declared as `G4long`, which is only 32 bits wide on Windows (LLP64 model), so even a correctly-obtained 64-bit size gets truncated and wraps to a negative number when stored.

With `fFileSize` negative, the buffer-fill loop in `ReadSomeDataFromFileToBuffer()` (`tellg() <= (fFileSize - fRecordLength)`) is false from the very first check, so the particle buffer is left empty. `TsGeneratorPhaseSpace::GeneratePrimaries()` then reads `front()` on an empty queue, which is why the run aborts immediately with:

```
Phase Space file header indicates phase space is in Limited form.
TsGeneratorPhaseSpace::GeneratePrimaries error: First particle in buffer not a new history.
```

regardless of the `LimitedAssume*IsNewHistory` workaround flags - the buffer was never actually populated, so those flags never got a chance to matter. With `PhaseSpacePreCheck=True` instead, the symptom is:

```
Number of Scored Particles listed in the header does not match the
number of particles counted in the actual file.
HeaderNumberOfParticles: 126491813, PreCheckNumberOfParticles: 1
```

This is Windows/MinGW-specific: on Linux/macOS, `off_t` and `long` are both 64-bit, so the bug is masked there.

## Fix
- `GetFileSize()` now uses `std::filesystem::file_size()` (64-bit safe on all platforms) instead of `stat()`.
- `fFileSize` (and `GetFileSize()`'s return type) changed from `G4long` to `int64_t` so the value isn't truncated back down on Windows.
- Also open the `.phsp` data file in `std::ios::binary` mode for the Binary/Limited formats. Opening a binary phase-space file in text mode on Windows risks the CRT's CR/LF translation and Ctrl-Z (`0x1A`) as-EOF handling corrupting raw binary data. This turned out not to be the actual cause of this particular bug, but it's a latent correctness issue worth closing at the same time since it's the same code path.

## Testing
Verified on native Windows (MSYS2/MinGW, Geant4 11.2.1 MT, built with CMake+Ninja) against a 4.17 GB legacy IAEA phase space file (NRC "ELEKTA_PRECISE_6mv" dataset, `$RECORD_LENGTH=33`, Z not stored, 2 extra longs for history-number bookkeeping):

- Before the fix: `GetFileSize()` returns `-1` (`stat()` failure); after switching only `GetFileSize()` to a 64-bit-safe implementation without also widening `fFileSize`, the value wraps to a large negative number when truncated back to 32 bits, reproducing the same failure.
- After the full fix: runs from 20,000 up to 53,000,000 histories all complete correctly, with `Total number of histories` matching the requested count and non-zero, physically sane dose results in the scorer output.

Diagnosed and reported in #278.